### PR TITLE
README: add deprecation notice and pointer to provider-upjet-github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # provider-github
 
+> [!WARNING]
+> **Deprecated:** Use <https://github.com/crossplane-contrib/provider-upjet-github> instead.
+
 ## Overview
 
 `provider-github` is the Crossplane infrastructure provider for


### PR DESCRIPTION
### Description of your changes

This PR adds a warning notice to the main README that notifies visitors to this repo of its deprecated/archived status. It also points to the new https://github.com/crossplane-contrib/provider-upjet-github repo that is meant to replace it.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

I've verified the rendered markdown in my fork: https://github.com/jbw976/provider-github/blob/archive/README.md 

[contribution process]: https://git.io/fj2m9
